### PR TITLE
make it library friendly

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+# Allows to be imported from another directory without fixing imports
+import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,5 @@
 # Allows to be imported from another directory without fixing imports
-import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/conf_extract.py
+++ b/conf_extract.py
@@ -1,7 +1,8 @@
-import malduck
 import re
-import sys
 import struct
+import sys
+
+import malduck
 import structlog
 
 shellcode_base_addr = 0x10000C00

--- a/conf_extract.py
+++ b/conf_extract.py
@@ -4,7 +4,7 @@ import sys
 from contextlib import suppress
 
 HAVE_MALDUCK = False
-HAVE_PYCRYPTODOTMEX = False
+HAVE_PYCRYPTODOMEX = False
 
 with suppress(ImportError):
     import malduck
@@ -13,7 +13,7 @@ with suppress(ImportError):
 with suppress(ImportError):
     from Crypto.Cipher import ARC4
     ARC4.key_size = range(1, 257)
-    HAVE_PYCRYPTODOTMEX = True
+    HAVE_PYCRYPTODOMEX = True
 
 
 import structlog
@@ -84,7 +84,7 @@ def extract_c2_buffers(stage_3_shellcode):
             rc4_key = stage_3_shellcode[c2_addr+1:c2_addr+5]
             if HAVE_MALDUCK:
                 c2 = malduck.rc4(rc4_key, stage_3_shellcode[c2_addr+5:c2_addr+5+len_c2]).decode("utf-8")
-            elif HAVE_PYCRYPTODOTMEX:
+            elif HAVE_PYCRYPTODOMEX:
                 c2 = ARC4.new(rc4_key).decrypt(stage_3_shellcode[c2_addr+5:c2_addr+5+len_c2]).decode("utf-8")
             c2s.append(c2)
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import math
+import os
 import struct
 import sys
 
@@ -16,18 +17,19 @@ import conf_extract
 import deobfuscation
 import unicorn_pe_loader
 
+cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 def estimate_shannon_entropy(dna_sequence):
     m = len(dna_sequence)
     bases = collections.Counter([tmp_base for tmp_base in dna_sequence])
- 
+
     shannon_entropy_value = 0
     for base in bases:
         n_i = bases[base]
         p_i = n_i / float(m)
         entropy_i = p_i * (math.log(p_i, 2))
         shannon_entropy_value += entropy_i
- 
+
     return shannon_entropy_value * -1
 
 def init_logger():
@@ -56,9 +58,9 @@ def init_logger():
 
 def emulate_decompress_call(emulator:unicorn_pe_loader.InitUnicorn, start_func, end_func, compressed_data, decompressed_size):
     logger = structlog.get_logger(__name__)
-    
+
     logger.info("starting emulation", start_addr="0x%x" % start_func, end_func="0x%x" % end_func)
-    
+
     # reset stack
     logger.info("setting stack and regs")
     emulator.create_stack()
@@ -73,7 +75,7 @@ def emulate_decompress_call(emulator:unicorn_pe_loader.InitUnicorn, start_func, 
 
     emulator.mu.mem_map(decompressed_addr, 32*1024)
     emulator.push_arg(decompressed_addr)
-    
+
     # write our data to be decompressed
     compressed_addr = 0x80000000
 
@@ -84,10 +86,10 @@ def emulate_decompress_call(emulator:unicorn_pe_loader.InitUnicorn, start_func, 
         pass
 
     emulator.mu.mem_map(compressed_addr, 32*1024)
-    
+
     emulator.mu.mem_write(compressed_addr, compressed_data)
     emulator.push_arg(compressed_addr)
-    
+
     emulator.push_arg(0)
 
     emulator.init_regs()
@@ -98,7 +100,7 @@ def emulate_decompress_call(emulator:unicorn_pe_loader.InitUnicorn, start_func, 
         logger.error("error during emulation", error=e)
         decompressed_data = emulator.mu.mem_read(decompressed_addr, decompressed_size)
         return decompressed_data
-    
+
     decompressed_data = emulator.mu.mem_read(decompressed_addr, decompressed_size)
     return decompressed_data
 
@@ -108,7 +110,7 @@ def decompress_buffer(emulator:unicorn_pe_loader.InitUnicorn, decrypted_stage_3)
 
     decompressed_size = struct.unpack("I", decrypted_stage_3[:4])[0]
     logger.info("decompressed info", decompressed_size="0x%x" % decompressed_size)
-    
+
     decrypted_stage_3 = decrypted_stage_3[4:]
     start_func = 0x00401258
     end_func = 0x0040137E
@@ -122,18 +124,18 @@ def deobfuscate_unpacked_smokeloader(sample_data:bytearray, emulator:unicorn_pe_
 
     opaque_predicate_info = deobfuscation.get_opaque_predicate_offsets(sample_data, pe_rep)
     cleaned_pe = deobfuscation.replace_ops(sample_data, opaque_predicate_info)
-   
+
     patched_filename = sample_path.split(".")[0] + "_no_opaque_predicates.bin"
     with open(patched_filename, "wb") as f:
         f.write(cleaned_pe)
-    
+
     cleaned_pe_rep = pefile.PE(data=cleaned_pe)
-    
+
     # decrypt the function bodies
     decrypted_bodies_pe, xor_cookie = deobfuscation.bulk_decrypt_function_bodies(cleaned_pe, patched_filename, emulator)
     if decrypted_bodies_pe is None:
         return None, None
-    
+
     # remove another set of opaque predicates
     opaque_predicate_info = deobfuscation.get_opaque_predicate_offsets(decrypted_bodies_pe, cleaned_pe_rep)
     decrypted_bodies_pe = deobfuscation.replace_ops(decrypted_bodies_pe, opaque_predicate_info)
@@ -142,7 +144,7 @@ def deobfuscate_unpacked_smokeloader(sample_data:bytearray, emulator:unicorn_pe_
 
 
 def get_payloads_from_stage_2(sample_data:bytearray, emulator:unicorn_pe_loader.InitUnicorn, xored_pe):
-    # xored_pe is the entire PE file XOR crypted with the single byte key. This ensures all the function bodies 
+    # xored_pe is the entire PE file XOR crypted with the single byte key. This ensures all the function bodies
     # are decrypted and we can identify the offsets
     logger = structlog.get_logger(__name__)
 
@@ -158,7 +160,7 @@ def get_payloads_from_stage_2(sample_data:bytearray, emulator:unicorn_pe_loader.
         except:
             logger.error("unable to get payload", rva="0x%x" % offset)
             continue
-        
+
         entropy_payload = estimate_shannon_entropy(payload)
         if entropy_payload < 7.9:
             logger.error("data most likely isn't our payload", offset="0x%x" % offset, size="0x%x" % size, entropy="%lf" % entropy_payload)
@@ -169,30 +171,23 @@ def get_payloads_from_stage_2(sample_data:bytearray, emulator:unicorn_pe_loader.
     return payloads
 
 
-parser = argparse.ArgumentParser(description='Smoke Conf Extract')
-parser.add_argument('--json', action='store_true')
-parser.add_argument('sample')
-
-
-def main():
+def main(sample: str, destination: str = "", disable_logging: bool = False):
     logger = structlog.get_logger(__name__)
-    init_logger() 
+    if disable_logging:
+        init_logger()
 
-    args = parser.parse_args()
-
-    with open(args.sample, "rb") as f:
+    with open(sample, "rb") as f:
         smokeloader_unpacked_pe = f.read()
-    
+
     emulator = unicorn_pe_loader.InitUnicorn(smokeloader_unpacked_pe, logger, type_pe=True, bit=32, debug=False)
 
-    deobfuscated_pe, xor_cookie = deobfuscate_unpacked_smokeloader(smokeloader_unpacked_pe, emulator, args.sample)
+    deobfuscated_pe, xor_cookie = deobfuscate_unpacked_smokeloader(smokeloader_unpacked_pe, emulator, sample)
     if deobfuscated_pe is None:
         logger.error("unable to deobfuscate PE file")
-        return 
-    
-    just_xored_pe = malduck.xor(xor_cookie & 0xFF, smokeloader_unpacked_pe)
+        return
 
-    with open(args.sample + "_fully_deobfuscated.bin", "wb") as f:
+    just_xored_pe = malduck.xor(xor_cookie & 0xFF, smokeloader_unpacked_pe)
+    with open(os.path.join(destination, f"{os.path.basename(sample)}_fully_deobfuscated.bin"), "wb") as f:
         f.write(deobfuscated_pe)
 
     payloads = get_payloads_from_stage_2(deobfuscated_pe, emulator, just_xored_pe)
@@ -200,7 +195,7 @@ def main():
         logger.error("unable to extract final stage")
         return
 
-    with open("./decompress_client.pe_file", "rb") as f:
+    with open(os.path.join(cur_dir, "decompress_client.pe_file"), "rb") as f:
         decompress_client = f.read()
     decompress_emulator = unicorn_pe_loader.InitUnicorn(decompress_client, logger, type_pe=True, bit=32, debug=False)
 
@@ -211,17 +206,17 @@ def main():
         decompressed_data = decompress_buffer(decompress_emulator, decrypted_stage_3)
         if decompressed_data is None:
             logger.error("unable to decompress data")
-            return 
-        
-    
+            return
+
+
         stage_3_hash = hashlib.md5(decompressed_data).hexdigest()
         entropy = estimate_shannon_entropy(decompressed_data)
         if entropy < 5 or entropy > 7:
             logger.error("unable to decompress final stage", entropy=entropy, size="0x%x" % len(decompressed_data), hash_stage_3=stage_3_hash)
             continue
         logger.info("successfully decompressed stage 3", size="0x%x" % len(decompressed_data), hash_stage_3=stage_3_hash, new_entropy="%lf" % entropy)
-    
-        with open(stage_3_hash + ".bin", "wb") as f:
+
+        with open(os.path.join(destination, stage_3_hash+ ".bin"), "wb") as f:
             f.write(decompressed_data)
 
         affiliate_id = conf_extract.extract_affiliate_id_from_stage_2(deobfuscated_pe)
@@ -237,27 +232,30 @@ def main():
         for decrypt_key in decrypt_keys:
             if decrypt_key in encrypt_keys:
                 encrypt_keys.remove(decrypt_key)
-        
+
         if len(encrypt_keys) == 1 and len(decrypt_keys) == 1:
             logger.info("RC4 keys", encrypt_key="0x%x" % encrypt_keys[0], decrypt_key="0x%x" % decrypt_keys[0])
 
         version = conf_extract.extract_version(decompressed_data)
         logger.info("version info", version=version)
         if len(c2s) > 0:
-            config = json.dumps({
+            return {
                 "family": "smokeloader",
                 "c2s": c2s,
                 "networkEncryptionKey": "%x" % encrypt_keys[0],
                 "networkDecryptionKey": "%x" % decrypt_keys[0],
                 "affiliateID": affiliate_id,
                 "version": version
-            }, indent=" " * 4)
-        
-        break
-    
-    if args.json:
-        print(config)
+            }
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description='Smoke Conf Extract')
+    parser.add_argument('--json', action='store_true')
+    parser.add_argument('--destination', action='store', default="", type=str, help="Destination folder where to store extracted files")
+    parser.add_argument('--disable-logging', action='store_true', default=False)
+    parser.add_argument('sample')
+    args = parser.parse_args()
+    config = main(args.sample, args.destination, args.disable_logging)
+    if args.json:
+        print(json.dumps(config, indent=" " * 4))

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import os
 import struct
 import sys
 from itertools import cycle
+from contextlib import suppress
 
 import pefile
 import structlog
@@ -73,10 +74,8 @@ def emulate_decompress_call(emulator:unicorn_pe_loader.InitUnicorn, start_func, 
     decompressed_addr = 0x70000000
 
     # ensure our given section is unmapped at start
-    try:
-        emulator.mu.mem_unmap(decompressed_addr, 32*1024)
-    except:
-        pass
+    with suppress(unicorn.UcError):
+        emulator.mu.mem_unmap(decompressed_addr, 32 * 1024)
 
     emulator.mu.mem_map(decompressed_addr, 32*1024)
     emulator.push_arg(decompressed_addr)
@@ -85,18 +84,13 @@ def emulate_decompress_call(emulator:unicorn_pe_loader.InitUnicorn, start_func, 
     compressed_addr = 0x80000000
 
     # ensure our given section is unmapped at start
-    try:
-        emulator.mu.mem_unmap(compressed_addr, 32*1024)
-    except:
-        pass
+    with suppress(unicorn.UcError):
+        emulator.mu.mem_unmap(compressed_addr, 32 * 1024)
 
     emulator.mu.mem_map(compressed_addr, 32*1024)
-
     emulator.mu.mem_write(compressed_addr, compressed_data)
     emulator.push_arg(compressed_addr)
-
     emulator.push_arg(0)
-
     emulator.init_regs()
 
     try:

--- a/pe_analysis.py
+++ b/pe_analysis.py
@@ -1,9 +1,11 @@
-import r2pipe
 import json
+
+import r2pipe
+
 
 # afl               - list all functions
 # afll              - list all functions with metadata
-# axt               - get xrefs from function? 
+# axt               - get xrefs from function?
 # pdf @0x18002adb8  - disassemble function at address
 class PEAnalysis:
     def __init__(self, filepath):
@@ -13,8 +15,7 @@ class PEAnalysis:
         self.json_data = {}
         self.init_function_data()
 
-        return 
-
+        return
 
     def init_function_data(self):
         attempts = 10
@@ -24,22 +25,21 @@ class PEAnalysis:
                     exit()
                 json_func_data = json.loads(self.r2_rep.cmd("aflj"))
             except:
-                attempts-=1
+                attempts -= 1
                 continue
             break
-        
+
         for entry in json_func_data:
             entry_data = {}
-            
+
             entry_data["fcn_name"] = entry["name"]
             entry_data["size"] = entry["realsz"]
-            
+
             xref_list = self.generate_xrefs(entry)
             entry_data["xrefs"] = xref_list
-            self.json_data[entry["offset"]] = entry_data 
-        
-        return 
+            self.json_data[entry["offset"]] = entry_data
 
+        return
 
     def generate_xrefs(self, entry):
         xrefs = self.r2_rep.cmd("axtj @0x%x" % int(entry["offset"]))
@@ -47,44 +47,42 @@ class PEAnalysis:
         xref_list = []
         for xref in json_loaded_xrefs:
             xref_data = {}
-            xref_data["from"] = xref["from"] 
+            xref_data["from"] = xref["from"]
             if "name" in xref:
                 xref_data["fcn_name"] = xref["name"].split("+")[0]
             elif "fcn_name" in xref:
                 xref_data["fcn_name"] = xref["fcn_name"]
-            
-            xref_list.append(xref_data)
-        
-        return xref_list
 
+            xref_list.append(xref_data)
+
+        return xref_list
 
     def get_xref_list(self, target_addr):
         xrefs = []
         if target_addr in self.json_data:
             entry = self.json_data[target_addr]
-            for xref in entry['xrefs']:
+            for xref in entry["xrefs"]:
                 xrefs.append(xref["from"])
         return xrefs
 
     def get_func_start_and_size_till_call(self, xref):
         func_start, func_end = self.get_func_start_and_size_till_end(xref)
-        return func_start, xref-func_start
+        return func_start, xref - func_start
 
     def get_func_start_and_size_till_end(self, mem_addr):
         for func_start_addr, func_info in self.json_data.items():
             func_end_addr = func_start_addr + func_info["size"]
             if mem_addr > func_start_addr and mem_addr <= func_end_addr:
                 return func_start_addr, func_end_addr
-        
+
         return None, None
-    
 
     def get_func_start(self, mem_addr):
         start_addrs = [x for x in self.json_data]
         start_addrs.sort()
-        for i in range(len(start_addrs)-1):
+        for i in range(len(start_addrs) - 1):
 
-            if start_addrs[i] < mem_addr < start_addrs[i+1]:
+            if start_addrs[i] < mem_addr < start_addrs[i + 1]:
                 return start_addrs[i]
-        
+
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,8 @@
 capstone==4.0.2
 cffi==1.15.1
-click==8.1.3
-cryptography==38.0.1
-dnfile==0.11.0
-future==0.18.2
-hexdump==3.3
 pefile==2022.5.30
 pycparser==2.21
 pycryptodomex==3.15.0
-pyelftools==0.29
 r2pipe==1.7.3
 structlog==22.1.0
-typing_extensions==4.3.0
 unicorn==2.0.0
-yara-python==4.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cryptography==38.0.1
 dnfile==0.11.0
 future==0.18.2
 hexdump==3.3
-malduck==4.3.0
 pefile==2022.5.30
 pycparser==2.21
 pycryptodomex==3.15.0

--- a/unicorn_pe_loader.py
+++ b/unicorn_pe_loader.py
@@ -2,19 +2,35 @@ import collections
 import struct
 
 import pefile
-from capstone import *
-from capstone.x86 import *
-from unicorn import *
-from unicorn.x86_const import *
+from capstone import Cs, CS_ARCH_X86, CS_MODE_32
+from unicorn import (
+    unicorn,
+    Uc,
+    UC_HOOK_CODE,
+    UC_ARCH_X86,
+    UC_MODE_32,
+    UC_MODE_64,
+    UC_HOOK_MEM_INVALID,
+    UC_MEM_WRITE,
+    UC_MEM_READ,
+    UC_MEM_FETCH,
+    UC_MEM_READ_UNMAPPED,
+    UC_MEM_WRITE_UNMAPPED,
+    UC_MEM_FETCH_UNMAPPED,
+    UC_MEM_WRITE_PROT,
+    UC_MEM_FETCH_PROT,
+    UC_MEM_READ_AFTER,
+)
 
-IMAGE_FILE_MACHINE_I386 = 0x014c
+IMAGE_FILE_MACHINE_I386 = 0x014C
 IMAGE_FILE_MACHINE_AMD64 = 0x8664
+
 
 class InitUnicorn(object):
     def __init__(self, data, logger, type_pe=False, bit=32, debug=False, data_addr=0xDEADBEEF00000000):
         self.logger = logger
         self.data_addr = data_addr
-        self.data_size = 2 * 1024 * 1024 
+        self.data_size = 2 * 1024 * 1024
         self.code_base = 0x00400000
         self.DEBUG = debug
         self.is_stack_mapped = False
@@ -50,29 +66,29 @@ class InitUnicorn(object):
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_EDX, self.data_addr)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_ESI, self.data_addr)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_EDI, self.data_addr)
-            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R8,  self.data_addr)
-            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R9,  self.data_addr)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R8, self.data_addr)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R9, self.data_addr)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R10, self.data_addr)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R11, self.data_addr)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R12, self.data_addr)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R13, self.data_addr)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R14, self.data_addr)
-            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R15, self.data_addr)  
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R15, self.data_addr)
         else:
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_EAX, 0xAAAAAAAAAAAAAAAA)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_EBX, 0xBBBBBBBBBBBBBBBB)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_ECX, 0xCCCCCCCCCCCCCCCC)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_EDX, 0xDDDDDDDDDDDDDDDD)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_ESI, 0xEEEEEEEEEEEEEEEE)
-            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_DI,  0xFFFFFFFFFFFFFFFF)
-            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R8,  0xABABABABABABABAB)
-            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R9,  0xBCBCBCBBCBCBCBCB)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_DI, 0xFFFFFFFFFFFFFFFF)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R8, 0xABABABABABABABAB)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R9, 0xBCBCBCBBCBCBCBCB)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R10, 0xCDCDCDCDCDCDCDCD)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R11, 0xDEDEDEDEDEDEDEDE)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R12, 0xDFDFDFDFDFDFDFDF)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R13, 0xACACACACACACACAC)
             self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R14, 0xADADADADADADADAD)
-            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R15, 0xAEAEAEAEAEAEAEAE)  
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_R15, 0xAEAEAEAEAEAEAEAE)
 
     def set_ret_hook(self):
         self.ret_hook = self.mu.hook_add(UC_HOOK_CODE, self.hook_ret_code)
@@ -81,9 +97,9 @@ class InitUnicorn(object):
         self.mu.hook_del(self.ret_hook)
 
     def push_arg(self, val):
-        esp = self.mu.reg_read(UC_X86_REG_ESP)
-        self.mu.mem_write(esp-4, struct.pack("<I", val))
-        self.mu.reg_write(UC_X86_REG_ESP, esp-4)
+        esp = self.mu.reg_read(unicorn.x86_const.UC_X86_REG_ESP)
+        self.mu.mem_write(esp - 4, struct.pack("<I", val))
+        self.mu.reg_write(unicorn.x86_const.UC_X86_REG_ESP, esp - 4)
 
     def create_stack(self):
         if self.is_x86_machine:
@@ -92,20 +108,20 @@ class InitUnicorn(object):
             self.stack_size = 0x00100000
         else:
             self.is_x86_machine = False
-            self.stack_base = 0xffffffff00000000
+            self.stack_base = 0xFFFFFFFF00000000
             self.stack_size = 0x0000000000100000
-        
+
         if not self.is_stack_mapped:
             self.mu.mem_map(self.stack_base, self.stack_size)
             self.is_stack_mapped = True
 
         self.mu.mem_write(self.stack_base, b"\x00" * self.stack_size)
         if self.is_x86_machine:
-            self.mu.reg_write(UC_X86_REG_ESP, self.stack_base + 0x800)
-            self.mu.reg_write(UC_X86_REG_EBP, self.stack_base + 0x1000)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_ESP, self.stack_base + 0x800)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_EBP, self.stack_base + 0x1000)
         else:
-            self.mu.reg_write(UC_X86_REG_RSP, self.stack_base + 0x8000)
-            self.mu.reg_write(UC_X86_REG_RBP, self.stack_base + 0x10000)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_RSP, self.stack_base + 0x8000)
+            self.mu.reg_write(unicorn.x86_const.UC_X86_REG_RBP, self.stack_base + 0x10000)
 
     def init_unicorn(self):
         if self.is_x86_machine:
@@ -134,15 +150,15 @@ class InitUnicorn(object):
 
     def prep_registers_for_c2(self):
         self.mu.reg_write(unicorn.x86_const.UC_X86_REG_RCX, self.data_addr)
-        self.mu.reg_write(unicorn.x86_const.UC_X86_REG_RDX, self.data_addr+4)
+        self.mu.reg_write(unicorn.x86_const.UC_X86_REG_RDX, self.data_addr + 4)
         return self.data_addr
-    
+
     def clear_arbitrary_data_section(self):
         self.mu.mem_write(self.data_addr, b"\x00" * self.data_size)
 
     def clear_registers_for_c2(self):
         self.mu.mem_write(self.data_addr, b"\x00\x00\x00\x00")
-        self.mu.mem_write(self.data_addr+4, b"\x00\x00\x00\x00")
+        self.mu.mem_write(self.data_addr + 4, b"\x00\x00\x00\x00")
 
     def map_pe_mem(self):
         # data_mapping_size = required_mapping_size(data_size)
@@ -156,7 +172,7 @@ class InitUnicorn(object):
             self.mu.mem_write(section.va, temp_bytes)
 
     def get_map(self):
-        MapEntry = collections.namedtuple('MapEntry', ['va', 'size'])
+        MapEntry = collections.namedtuple("MapEntry", ["va", "size"])
         ret = []
         for section in self.pe.sections:
             rva = section.VirtualAddress
@@ -190,44 +206,41 @@ class InitUnicorn(object):
 
     def hook_ret_code(self, uc, address, size, user_data):
         for i in self.md.disasm(uc.mem_read(address, size), address):
-            if i.mnemonic == 'ret':
+            if i.mnemonic == "ret":
                 uc.emu_stop()
         return
 
     def hook_code(self, uc, address, size, user_data):
-        self.logger.info('Tracing instruction at 0x%x, instruction size = 0x%x' % (address, size))
+        self.logger.info("Tracing instruction at 0x%x, instruction size = 0x%x" % (address, size))
         return
 
     def hook_call(self, uc, address, size, user_data):
-        self.logger.info('Call instruction at 0x%x, instruction size = 0x%x' % (address, size))
+        self.logger.info("Call instruction at 0x%x, instruction size = 0x%x" % (address, size))
         return
 
     def hook_mem_invalid(self, uc, access, address, size, value, user_data):
-        eip = uc.reg_read(UC_X86_REG_EIP)
+        eip = uc.reg_read(unicorn.x86_const.UC_X86_REG_EIP)
         if access == UC_MEM_WRITE:
             self.logger.error("invalid WRITE of 0x%x at 0x%X, data size = %u, data value = 0x%x" % (address, eip, size, value))
-        if access == UC_MEM_READ:
+        elif access == UC_MEM_READ:
             self.logger.error("invalid READ of 0x%x at 0x%X, data size = %u" % (address, eip, size))
-        if access == UC_MEM_FETCH:
+        elif access == UC_MEM_FETCH:
             self.logger.error("UC_MEM_FETCH of 0x%x at 0x%X, data size = %u" % (address, eip, size))
-        if access == UC_MEM_READ_UNMAPPED:
+        elif access == UC_MEM_READ_UNMAPPED:
             self.logger.error("UC_MEM_READ_UNMAPPED of 0x%x at 0x%X, data size = %u" % (address, eip, size))
-        if access == UC_MEM_WRITE_UNMAPPED:
+        elif access == UC_MEM_WRITE_UNMAPPED:
             self.logger.error("UC_MEM_WRITE_UNMAPPED of 0x%x at 0x%X, data size = %u" % (address, eip, size))
             size_map = 0x10000
             self.logger.info("mapping addr 0x%x (0x%x) to continue execution" % (address, size_map))
             self.key_addr = address
             uc.mem_map(address, size_map)
             return True
- 
-        if access == UC_MEM_FETCH_UNMAPPED:
+        elif access == UC_MEM_FETCH_UNMAPPED:
             self.logger.error("UC_MEM_FETCH_UNMAPPED of 0x%x at 0x%X, data size = %u" % (address, eip, size))
-        if access == UC_MEM_WRITE_PROT:
+        elif access == UC_MEM_WRITE_PROT:
             self.logger.error("UC_MEM_WRITE_PROT of 0x%x at 0x%X, data size = %u" % (address, eip, size))
-        if access == UC_MEM_FETCH_PROT:
+        elif access == UC_MEM_FETCH_PROT:
             self.logger.error("UC_MEM_FETCH_PROT of 0x%x at 0x%X, data size = %u" % (address, eip, size))
-        if access == UC_MEM_FETCH_PROT:
-            self.logger.error("UC_MEM_FETCH_PROT of 0x%x at 0x%X, data size = %u" % (address, eip, size))
-        if access == UC_MEM_READ_AFTER:
+        elif access == UC_MEM_READ_AFTER:
             self.logger.error("UC_MEM_READ_AFTER of 0x%x at 0x%X, data size = %u" % (address, eip, size))
         return False


### PR DESCRIPTION
Hello, first of all thanks for all your amazing job on this one. I did small update to make it easier to use as library, i do have my personal extractor but sometime sandbox run fails due to different reason and be able to get payload from second stage is huge +. 

I have run `isort` to sort imports and `black` to improve a bit code minimalistic.


```
from main import main
conf = main("test/<redacted>", disable_logging=True)
>>> conf
{'family': 'smokeloader', 'c2s': ['http://host-file-host6.com/', 'http://host-host-file8.com/'], 'networkEncryptionKey': '<redacted>', 'networkDecryptionKey': '<redacted>', 'affiliateID': '<redacted>', 'version': 2020}
```

it still gives you log if you disable part of it but it reduced
```
2022-10-17T08:07:06.811224Z [info     ] opaque predicate found         [deobfuscation] first_comparison=8 rva=0x401140 second_comparison=6
2022-10-17T08:07:06.815712Z [info     ] opaque predicate found         [deobfuscation] first_comparison=7 rva=0x401151 second_comparison=5
2022-10-17T08:07:06.815802Z [info     ] opaque predicate found         [deobfuscation] first_comparison=6 rva=0x402d41 second_comparison=4
2022-10-17T08:07:06.815884Z [info     ] opaque predicate found         [deobfuscation] first_comparison=7 rva=0x402d4e second_comparison=5
2022-10-17T08:07:06.816115Z [info     ] opaque predicate found         [deobfuscation] first_comparison=5 rva=0x402d8e second_comparison=3
2022-10-17T08:07:06.816188Z [info     ] opaque predicate found         [deobfuscation] first_comparison=5 rva=0x402dfa second_comparison=3
2022-10-17T08:07:06.816251Z [info     ] opaque predicate found         [deobfuscation] first_comparison=7 rva=0x402e28 second_comparison=5
2022-10-17T08:07:06.816312Z [info     ] opaque predicate found         [deobfuscation] first_comparison=7 rva=0x402ea7 second_comparison=5
2022-10-17T08:07:06.816396Z [info     ] opaque predicate found         [deobfuscation] first_comparison=6 rva=0x401177 second_comparison=4
2022-10-17T08:07:06.816464Z [info     ] opaque predicate found         [deobfuscation] first_comparison=5 rva=0x4011ba second_comparison=3
2022-10-17T08:07:06.816550Z [info     ] opaque predicate found         [deobfuscation] first_comparison=5 rva=0x4011c7 second_comparison=3
2022-10-17T08:07:06.816625Z [info     ] opaque predicate found         [deobfuscation] first_comparison=4 rva=0x402d9a second_comparison=2
2022-10-17T08:07:06.816692Z [info     ] opaque predicate found         [deobfuscation] first_comparison=4 rva=0x402ddd second_comparison=2
2022-10-17T08:07:06.816760Z [info     ] opaque predicate found         [deobfuscation] first_comparison=4 rva=0x402e0b second_comparison=2
2022-10-17T08:07:06.816821Z [info     ] opaque predicate found         [deobfuscation] first_comparison=6 rva=0x402e37 second_comparison=4
INFO: Analyze all flags starting with sym. and entry0 (aa)
INFO: Analyze all functions arguments/locals (afva@@@F)
INFO: Analyze function calls (aac)
INFO: Analyze len bytes of instructions for references (aar)
INFO: Finding and parsing C++ vtables (avrr)
INFO: Type matching analysis for all functions (aaft)
INFO: Propagate noreturn information (aanr)
INFO: Use -AA or aaaa to perform additional experimental analysis
2022-10-17T08:07:07.213858Z [info     ] calls recovered                [deobfuscation] n_calls=12
2022-10-17T08:07:07.214168Z [info     ] xor cookie                     [deobfuscation] xor_key=<redacted>
2022-10-17T08:07:07.214393Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x401205 size_to_decrypt=0x4d xref_offset=0x401200
2022-10-17T08:07:07.214590Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x40148c size_to_decrypt=0x379 xref_offset=0x401487
2022-10-17T08:07:07.214928Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x40183e size_to_decrypt=0x60 xref_offset=0x401839
2022-10-17T08:07:07.215217Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x4018e3 size_to_decrypt=0x1b5 xref_offset=0x4018de
2022-10-17T08:07:07.215474Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x401b55 size_to_decrypt=0xc5 xref_offset=0x401b50
2022-10-17T08:07:07.215647Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x401c5e size_to_decrypt=0xca xref_offset=0x401c59
2022-10-17T08:07:07.215783Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x401d70 size_to_decrypt=0x83 xref_offset=0x401d6b
2022-10-17T08:07:07.215921Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x401ee4 size_to_decrypt=0x22c xref_offset=0x401edf
2022-10-17T08:07:07.216090Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x4028af size_to_decrypt=0x68 xref_offset=0x4028aa
2022-10-17T08:07:07.216209Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x402945 size_to_decrypt=0x98 xref_offset=0x402940
2022-10-17T08:07:07.216335Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x402a0b size_to_decrypt=0xa0 xref_offset=0x402a06
2022-10-17T08:07:07.216535Z [info     ] decrypt function body call     [deobfuscation] key=0xfe rva_to_decrypt_from=0x402ad7 size_to_decrypt=0xa9 xref_offset=0x402ad2
2022-10-17T08:07:07.216702Z [info     ] opaque predicate found         [deobfuscation] first_comparison=4 rva=0x401611 second_comparison=2
2022-10-17T08:07:07.216780Z [info     ] opaque predicate found         [deobfuscation] first_comparison=4 rva=0x4018eb second_comparison=2
2022-10-17T08:07:07.220409Z [info     ] payload info                   [main] entropy=7.928119 offset=0x402f68 size=0x229d
2022-10-17T08:07:07.221238Z [info     ] payload info                   [main] entropy=7.932163 offset=0x405205 size=0x2e0b
2022-10-17T08:07:07.221983Z [info     ] payload info                   [main] entropy=7.928119 offset=0x402f68 size=0x229d
2022-10-17T08:07:07.222786Z [info     ] payload info                   [main] entropy=7.932163 offset=0x405205 size=0x2e0b
2022-10-17T08:07:07.226006Z [info     ] decrypting extracted PE with key [main] key=<redacted> len_pe=8861
2022-10-17T08:07:07.226789Z [info     ] decompressed info              [main] decompressed_size=0x3800
2022-10-17T08:07:07.226885Z [info     ] starting emulation             [main] end_func=0x40137e start_addr=0x401258
2022-10-17T08:07:07.226949Z [info     ] setting stack and regs         [main]
2022-10-17T08:07:07.234739Z [info     ] successfully decompressed stage 3 [main] hash_stage_3=<redacted> new_entropy=6.061307 size=0x3800
2022-10-17T08:07:07.236208Z [info     ] affiliate info                 [main] affiliate_id=<redacted>
2022-10-17T08:07:07.236523Z [info     ] c2 info                        [main] c2=http://host-file-host6.com/
2022-10-17T08:07:07.236630Z [info     ] c2 info                        [main] c2=http://host-host-file8.com/
2022-10-17T08:07:07.236771Z [info     ] RC4 keys                       [main] decrypt_key=<redacted> encrypt_key=<redacted>
2022-10-17T08:07:07.236846Z [info     ] version info                   [main] version=2020
```